### PR TITLE
Add dit command

### DIFF
--- a/bin/dit
+++ b/bin/dit
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+# ------------------------------------------------
+# dit - short hand for git for dotfiles
+# ------------------------------------------------
+# As we control dotfiles as git's bare repo, 
+# it is cumbersome to type out whole work-tree
+# git command to interact with our dotfiles folder
+#
+# dit command gives us easy access to control out dotilfes
+# without deviating too much from our `git` command flow
+
+
+CONFIG_DIR=${XDG_CONFIG_HOME:=$HOME/.config}
+git --git-dir=$HOME/.dotfiles.git --work-tree=$CONFIG_DIR "$@"
+


### PR DESCRIPTION
dit command provides alias for interacting with the dotfiles bare repo without needing type out verbose git command.

A name "dit" was chosen so that

1. The typing flow is very similar to git (three letter and only first char is different)
2. Name just makes sense to me - (which may not be the case for others)